### PR TITLE
Fixed build on FreeBSD

### DIFF
--- a/publish/UnixBuild.sh
+++ b/publish/UnixBuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cargo build --release -p luals
 
@@ -6,6 +6,6 @@ if [ -d "dist" ]; then
     rm -rf dist
 fi
 
-mkdir bin
+mkdir -p  bin
 
 cp target/release/lua-language-server bin/


### PR DESCRIPTION
On FreeBSD and other systems bash is not always in /bin/bash.

Further add the `-p` flag to the `mkdir` to not fail if the directory already exists.